### PR TITLE
Fix wrong version string in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/mainProcess/main.js",
   "name": "lameta",
   "productName": "lameta",
-  "version": "3.0.9-alpha",
+  "version": "3.0.21-beta",
   "author": {
     "name": "lameta",
     "email": "sorryno@email.org"


### PR DESCRIPTION
For a little while now new releases have contained a dated version string, 3.0.9-alpha. This fixes it, but maybe an automated check or pre-commit script updating this for future releases would be helpful also...?